### PR TITLE
Allow mixed-case options

### DIFF
--- a/configparser.go
+++ b/configparser.go
@@ -34,11 +34,11 @@ var boolMapping = map[string]bool{
 }
 
 type Dict map[string]string
-type Config map[string]Dict
+type Config map[string]*Section
 
 type ConfigParser struct {
 	config   Config
-	defaults Dict
+	defaults *Section
 }
 
 // Keys returns a sorted slice of keys
@@ -64,17 +64,17 @@ func getNoOptionError(section, option string) error {
 func New() *ConfigParser {
 	return &ConfigParser{
 		config:   make(Config),
-		defaults: make(Dict),
+		defaults: newSection("defaults"),
 	}
 }
 
 func NewWithDefaults(defaults Dict) *ConfigParser {
 	p := ConfigParser{
 		config:   make(Config),
-		defaults: make(Dict),
+		defaults: newSection("defaults"),
 	}
 	for key, value := range defaults {
-		p.defaults[key] = value
+		p.defaults.Add(key, value)
 	}
 	return &p
 }
@@ -95,7 +95,7 @@ func parseFile(file *os.File) (*ConfigParser, error) {
 	reader := bufio.NewReader(file)
 	var lineNo int
 	var err error
-	var curSect Dict
+	var curSect *Section
 
 	for err == nil {
 		l, _, err := reader.ReadLine()
@@ -118,17 +118,14 @@ func parseFile(file *os.File) (*ConfigParser, error) {
 			if section == defaultSectionName {
 				curSect = p.defaults
 			} else if _, present := p.config[section]; !present {
-				curSect = make(Dict)
+				curSect = newSection(section)
 				p.config[section] = curSect
 			}
 		} else if match = keyValue.FindStringSubmatch(line); len(match) > 0 {
 			if curSect == nil {
 				return nil, fmt.Errorf("Missing Section Header: %d %s", lineNo, line)
 			} else {
-				option := match[1]
-				// separator := match[2]
-				value := p.transformOption(strings.TrimFunc(match[3], unicode.IsSpace))
-				curSect[option] = value
+				curSect.Add(match[1], match[3])
 			}
 		}
 	}
@@ -147,14 +144,14 @@ func Parse(filename string) (*ConfigParser, error) {
 	return p, nil
 }
 
-func writeSection(file *os.File, name, delimiter string, options Dict) error {
-	_, err := file.WriteString(fmt.Sprintf("[%s]\n", name))
+func writeSection(file *os.File, delimiter string, section *Section) error {
+	_, err := file.WriteString(fmt.Sprintf("[%s]\n", section.Name))
 	if err != nil {
 		return err
 	}
 
-	for _, key := range options.Keys() {
-		_, err = file.WriteString(fmt.Sprintf("%s %s %s\n", key, delimiter, options[key]))
+	for _, option := range section.Options() {
+		_, err = file.WriteString(fmt.Sprintf("%s %s %s\n", option, delimiter, section.options[option]))
 		if err != nil {
 			return err
 		}
@@ -171,20 +168,15 @@ func (p *ConfigParser) SaveWithDelimiter(filename, delimiter string) error {
 		return err
 	}
 
-	d := p.Defaults()
-	if len(d) > 0 {
-		err = writeSection(f, "defaults", delimiter, d)
+	if len(p.defaults.Options()) > 0 {
+		err = writeSection(f, delimiter, p.defaults)
 		if err != nil {
 			return err
 		}
 	}
 
 	for _, s := range p.Sections() {
-		d, err = p.Items(s)
-		if err != nil {
-			return err
-		}
-		err = writeSection(f, s, delimiter, d)
+		err = writeSection(f, delimiter, p.config[s])
 		if err != nil {
 			return err
 		}

--- a/configparser.go
+++ b/configparser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"unicode"
 )
@@ -38,6 +39,18 @@ type Config map[string]Dict
 type ConfigParser struct {
 	config   Config
 	defaults Dict
+}
+
+// Keys returns a sorted slice of keys
+func (d Dict) Keys() []string {
+	var keys []string
+
+	for key := range d {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	return keys
 }
 
 func getNoSectionError(section string) error {
@@ -139,8 +152,9 @@ func writeSection(file *os.File, name, delimiter string, options Dict) error {
 	if err != nil {
 		return err
 	}
-	for k, v := range options {
-		_, err = file.WriteString(fmt.Sprintf("%s %s %s\n", k, delimiter, v))
+
+	for _, key := range options.Keys() {
+		_, err = file.WriteString(fmt.Sprintf("%s %s %s\n", key, delimiter, options[key]))
 		if err != nil {
 			return err
 		}

--- a/example.cfg
+++ b/example.cfg
@@ -9,6 +9,7 @@ base_dir: /srv
 bin_dir: %(base_dir)s/bin
 
 [slave]
+FrobTimeout: 5
 max_build_time: 200
 builder_command: %(bin_dir)s/build
 log_dir: %(base_dir)s/logs

--- a/interpolation_test.go
+++ b/interpolation_test.go
@@ -41,6 +41,7 @@ func (s *ConfigParserSuite) TestItemsWithDefaultsInterpolated(c *C) {
 	c.Assert(result, DeepEquals, configparser.Dict{
 		"builder_command": "/srv/bin/build",
 		"bin_dir":         "/srv/bin",
+		"FrobTimeout":     "5",
 		"max_build_time":  "200",
 		"log_dir":         "/srv/logs",
 		"base_dir":        "/srv"})

--- a/methods_test.go
+++ b/methods_test.go
@@ -68,7 +68,7 @@ func (s *ConfigParserSuite) TestOptionsWithNoSection(c *C) {
 func (s *ConfigParserSuite) TestOptionsWithSection(c *C) {
 	result, err := s.p.Options("slave")
 	c.Assert(err, IsNil)
-	c.Assert(result, DeepEquals, []string{"base_dir", "bin_dir", "builder_command", "log_dir", "max_build_time"})
+	c.Assert(result, DeepEquals, []string{"FrobTimeout", "base_dir", "bin_dir", "builder_command", "log_dir", "max_build_time"})
 }
 
 // Options(section) should return an empty slice if there are no options in a section
@@ -97,6 +97,14 @@ func (s *ConfigParserSuite) TestGet(c *C) {
 	result, err := s.p.Get("slave", "max_build_time")
 	c.Assert(err, IsNil)
 	c.Assert(result, Equals, "200")
+}
+
+// Get(section, option) should return the option value for the named section
+// regardless of case
+func (s *ConfigParserSuite) TestGetCamelCase(c *C) {
+	result, err := s.p.Get("slave", "FrobTimeout")
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, "5")
 }
 
 // Get(section, option) should lookup the option in the DEFAULT section if requested
@@ -170,6 +178,7 @@ func (s *ConfigParserSuite) TestItemsWithSection(c *C) {
 	result, err := s.p.Items("slave")
 	c.Assert(err, IsNil)
 	c.Assert(result, DeepEquals, configparser.Dict{
+		"FrobTimeout":     "5",
 		"max_build_time":  "200",
 		"builder_command": "%(bin_dir)s/build",
 		"log_dir":         "%(base_dir)s/logs"})
@@ -180,6 +189,7 @@ func (s *ConfigParserSuite) TestItemsWithDefaults(c *C) {
 	result, err := s.p.ItemsWithDefaults("slave")
 	c.Assert(err, IsNil)
 	c.Assert(result, DeepEquals, configparser.Dict{
+		"FrobTimeout":     "5",
 		"max_build_time":  "200",
 		"base_dir":        "/srv",
 		"builder_command": "%(bin_dir)s/build",

--- a/section.go
+++ b/section.go
@@ -32,11 +32,7 @@ func (s *Section) Options() []string {
 }
 
 func (s *Section) Items() Dict {
-	items := make(Dict)
-	for _, option := range s.Options() {
-		items[option] = s.options[option]
-	}
-	return items
+	return s.options
 }
 
 func (s *Section) safeValue(in string) string {

--- a/section.go
+++ b/section.go
@@ -1,0 +1,57 @@
+package configparser
+
+import "strings"
+
+type Section struct {
+	Name    string
+	options Dict
+	lookup  Dict
+}
+
+func (s *Section) Add(key, value string) error {
+	lookupKey := s.safeKey(key)
+
+	s.options[key] = s.safeValue(value)
+	s.lookup[lookupKey] = key
+	return nil
+}
+
+func (s *Section) Get(key string) (string, error) {
+	lookupKey, present := s.lookup[s.safeKey(key)]
+	if !present {
+		return "", getNoOptionError(s.Name, key)
+	}
+	if value, present := s.options[lookupKey]; present {
+		return value, nil
+	}
+	return "", getNoOptionError(s.Name, key)
+}
+
+func (s *Section) Options() []string {
+	return s.options.Keys()
+}
+
+func (s *Section) Items() Dict {
+	items := make(Dict)
+	for _, option := range s.Options() {
+		items[option] = s.options[option]
+	}
+	return items
+}
+
+func (s *Section) safeValue(in string) string {
+	// Same as safeKey for now.
+	return s.safeKey(in)
+}
+
+func (s *Section) safeKey(in string) string {
+	return strings.ToLower(strings.TrimSpace(in))
+}
+
+func newSection(name string) *Section {
+	return &Section{
+		Name:    name,
+		options: make(Dict),
+		lookup:  make(Dict),
+	}
+}


### PR DESCRIPTION
This is a pair of commits which enable use of MixedCase options in addition to lower_case options. I can verify that Python's ConfigParser supports this, as I am trying to parse a common config file in both Python and Go.