### PR TITLE
Add LICENSE, fix RemoveOption and modernise gocheck.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2013-15 Kevin McDermott
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE

--- a/chainmap/chainmap_test.go
+++ b/chainmap/chainmap_test.go
@@ -4,19 +4,19 @@ import (
 	"github.com/bigkevmcd/go-configparser/chainmap"
 	"testing"
 
-	. "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
+func Test(t *testing.T) { gc.TestingT(t) }
 
 type ChainMapSuite struct {
 	dict1 chainmap.Dict
 	dict2 chainmap.Dict
 }
 
-var _ = Suite(&ChainMapSuite{})
+var _ = gc.Suite(&ChainMapSuite{})
 
-func (s *ChainMapSuite) SetUpTest(c *C) {
+func (s *ChainMapSuite) SetUpTest(c *gc.C) {
 	s.dict1 = make(chainmap.Dict)
 	s.dict2 = make(chainmap.Dict)
 	s.dict1["testing"] = "2"
@@ -24,30 +24,30 @@ func (s *ChainMapSuite) SetUpTest(c *C) {
 	s.dict2["value"] = "4"
 }
 
-func (s *ChainMapSuite) TestLen(c *C) {
+func (s *ChainMapSuite) TestLen(c *gc.C) {
 	chainMap := chainmap.New(s.dict1, s.dict2)
-	c.Assert(chainMap.Len(), Equals, 2)
+	c.Assert(chainMap.Len(), gc.Equals, 2)
 }
 
-func (s *ChainMapSuite) TestGet1(c *C) {
+func (s *ChainMapSuite) TestGet1(c *gc.C) {
 	chainMap := chainmap.New(s.dict1, s.dict2)
 
 	result := chainMap.Get("unknown")
-	c.Assert(result, Equals, "")
+	c.Assert(result, gc.Equals, "")
 }
 
-func (s *ChainMapSuite) TestGet2(c *C) {
+func (s *ChainMapSuite) TestGet2(c *gc.C) {
 	chainMap := chainmap.New(s.dict1, s.dict2)
 
 	result := chainMap.Get("value")
-	c.Assert(result, Equals, "4")
+	c.Assert(result, gc.Equals, "4")
 	result = chainMap.Get("testing")
-	c.Assert(result, Equals, "2")
+	c.Assert(result, gc.Equals, "2")
 }
 
-func (s *ChainMapSuite) TestGet3(c *C) {
+func (s *ChainMapSuite) TestGet3(c *gc.C) {
 	chainMap := chainmap.New(s.dict2, s.dict1)
 
 	result := chainMap.Get("value")
-	c.Assert(result, Equals, "3")
+	c.Assert(result, gc.Equals, "3")
 }

--- a/configparser_test.go
+++ b/configparser_test.go
@@ -2,7 +2,7 @@ package configparser_test
 
 import (
 	"github.com/bigkevmcd/go-configparser"
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 
 	"fmt"
 	"io/ioutil"

--- a/interpolation.go
+++ b/interpolation.go
@@ -16,7 +16,7 @@ func (p *ConfigParser) getInterpolated(section, option string, c *chainmap.Chain
 
 // return a string value for the named option.  All % interpolations are
 // expanded in the return values, based on the defaults passed into the
-// constructor and the DEFAULT section.  
+// constructor and the DEFAULT section.
 func (p *ConfigParser) GetInterpolated(section, option string) (string, error) {
 	o, err := p.Items(section)
 	if err != nil {

--- a/interpolation_test.go
+++ b/interpolation_test.go
@@ -3,7 +3,7 @@ package configparser_test
 import (
 	"github.com/bigkevmcd/go-configparser"
 
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 )
 
 // GetInterpolated(section, option) should return an appropriate error if the section does not exist

--- a/methods.go
+++ b/methods.go
@@ -192,3 +192,15 @@ func (p *ConfigParser) HasOption(section, option string) (bool, error) {
 	_, err := s.Get(option)
 	return err == nil, nil
 }
+
+func (p *ConfigParser) RemoveOption(section, option string) error {
+	var s *Section
+	if p.isDefaultSection(section) {
+		s = p.defaults
+	} else if _, present := p.config[section]; !present {
+		return getNoSectionError(section)
+	} else {
+		s = p.config[section]
+	}
+	return s.Remove(option)
+}

--- a/methods_test.go
+++ b/methods_test.go
@@ -3,181 +3,181 @@ package configparser_test
 import (
 	"github.com/bigkevmcd/go-configparser"
 
-	. "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 // Defaults() should return a map containing the parser defaults.
-func (s *ConfigParserSuite) TestDefaults(c *C) {
+func (s *ConfigParserSuite) TestDefaults(c *gc.C) {
 	d := s.p.Defaults()
-	c.Assert(d["base_dir"], Equals, "/srv")
+	c.Assert(d["base_dir"], gc.Equals, "/srv")
 }
 
 // Defaults() should return an empty Dict if there are no parser defaults
-func (s *ConfigParserSuite) TestDefaultsWithNoDefaults(c *C) {
+func (s *ConfigParserSuite) TestDefaultsWithNoDefaults(c *gc.C) {
 	p := configparser.New()
 	d := p.Defaults()
-	c.Assert(d, DeepEquals, configparser.Dict{})
+	c.Assert(d, gc.DeepEquals, configparser.Dict{})
 }
 
 // Sections() should return a list of section names excluding [DEFAULT]
-func (s *ConfigParserSuite) TestSections(c *C) {
+func (s *ConfigParserSuite) TestSections(c *gc.C) {
 	result := s.p.Sections()
-	c.Assert(result, DeepEquals, []string{"slave"})
+	c.Assert(result, gc.DeepEquals, []string{"slave"})
 }
 
 // AddSection(section) should create a new section in the configuration
-func (s *ConfigParserSuite) TestAddSection(c *C) {
+func (s *ConfigParserSuite) TestAddSection(c *gc.C) {
 	newParser := configparser.New()
 
 	err := newParser.AddSection("newsection")
 
-	c.Assert(err, IsNil)
-	c.Assert(newParser.Sections(), DeepEquals, []string{"newsection"})
+	c.Assert(err, gc.IsNil)
+	c.Assert(newParser.Sections(), gc.DeepEquals, []string{"newsection"})
 }
 
 // AddSection(section) should return an appropriate error if the section already exists
-func (s *ConfigParserSuite) TestAddSectionDuplicate(c *C) {
+func (s *ConfigParserSuite) TestAddSectionDuplicate(c *gc.C) {
 	err := s.p.AddSection("slave")
 
-	c.Assert(err, ErrorMatches, "Section 'slave' already exists")
+	c.Assert(err, gc.ErrorMatches, "Section 'slave' already exists")
 }
 
 // AddSection(section) should return an appropriate error if we attempt to add a default section
-func (s *ConfigParserSuite) TestAddSectionDefaultLowercase(c *C) {
+func (s *ConfigParserSuite) TestAddSectionDefaultLowercase(c *gc.C) {
 	newParser := configparser.New()
 	err := newParser.AddSection("default")
 
-	c.Assert(err, ErrorMatches, "Invalid section name: 'default'")
+	c.Assert(err, gc.ErrorMatches, "Invalid section name: 'default'")
 }
 
 // AddSection(section) should return an appropriate error if we attempt to add a DEFAULT section
-func (s *ConfigParserSuite) TestAddSectionDefaultUppercase(c *C) {
+func (s *ConfigParserSuite) TestAddSectionDefaultUppercase(c *gc.C) {
 	newParser := configparser.New()
 	err := newParser.AddSection("DEFAULT")
 
-	c.Assert(err, ErrorMatches, "Invalid section name: 'DEFAULT'")
+	c.Assert(err, gc.ErrorMatches, "Invalid section name: 'DEFAULT'")
 }
 
 // Options(section) should return an appropriate error if the section doesn't exist
-func (s *ConfigParserSuite) TestOptionsWithNoSection(c *C) {
+func (s *ConfigParserSuite) TestOptionsWithNoSection(c *gc.C) {
 	_, err := s.p.Options("unknown")
-	c.Assert(err, ErrorMatches, "No section: 'unknown'")
+	c.Assert(err, gc.ErrorMatches, "No section: 'unknown'")
 }
 
 // Options(section) should return a list of option names for a given section mixed in with the defaults
-func (s *ConfigParserSuite) TestOptionsWithSection(c *C) {
+func (s *ConfigParserSuite) TestOptionsWithSection(c *gc.C) {
 	result, err := s.p.Options("slave")
-	c.Assert(err, IsNil)
-	c.Assert(result, DeepEquals, []string{"FrobTimeout", "base_dir", "bin_dir", "builder_command", "log_dir", "max_build_time"})
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.DeepEquals, []string{"FrobTimeout", "base_dir", "bin_dir", "builder_command", "log_dir", "max_build_time"})
 }
 
 // Options(section) should return an empty slice if there are no options in a section
-func (s *ConfigParserSuite) TestOptionsWithEmptySection(c *C) {
+func (s *ConfigParserSuite) TestOptionsWithEmptySection(c *gc.C) {
 	newParser := configparser.New()
 	newParser.AddSection("testing")
 	result, err := newParser.Options("testing")
-	c.Assert(err, IsNil)
-	c.Assert(result, DeepEquals, []string{})
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.DeepEquals, []string{})
 }
 
 // Get(section, option) should return an appropriate error if the section does not exist
-func (s *ConfigParserSuite) TestGetWithMissingSection(c *C) {
+func (s *ConfigParserSuite) TestGetWithMissingSection(c *gc.C) {
 	_, err := s.p.Get("missing", "value")
-	c.Assert(err, ErrorMatches, "No section: 'missing'")
+	c.Assert(err, gc.ErrorMatches, "No section: 'missing'")
 }
 
 // Get(section, option) should return an appropriate error if the option does not exist within the section
-func (s *ConfigParserSuite) TestGetWithMissingOptionInSection(c *C) {
+func (s *ConfigParserSuite) TestGetWithMissingOptionInSection(c *gc.C) {
 	_, err := s.p.Get("slave", "missing")
-	c.Assert(err, ErrorMatches, "No option 'missing' in section: 'slave'")
+	c.Assert(err, gc.ErrorMatches, "No option 'missing' in section: 'slave'")
 }
 
 // Get(section, option) should return the option value for the named section
-func (s *ConfigParserSuite) TestGet(c *C) {
+func (s *ConfigParserSuite) TestGet(c *gc.C) {
 	result, err := s.p.Get("slave", "max_build_time")
-	c.Assert(err, IsNil)
-	c.Assert(result, Equals, "200")
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.Equals, "200")
 }
 
 // Get(section, option) should return the option value for the named section
 // regardless of case
-func (s *ConfigParserSuite) TestGetCamelCase(c *C) {
+func (s *ConfigParserSuite) TestGetCamelCase(c *gc.C) {
 	result, err := s.p.Get("slave", "FrobTimeout")
-	c.Assert(err, IsNil)
-	c.Assert(result, Equals, "5")
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.Equals, "5")
 }
 
 // Get(section, option) should lookup the option in the DEFAULT section if requested
-func (s *ConfigParserSuite) TestGetDefaultSection(c *C) {
+func (s *ConfigParserSuite) TestGetDefaultSection(c *gc.C) {
 	result, err := s.p.Get("DEFAULT", "bin_dir")
-	c.Assert(err, IsNil)
-	c.Assert(result, Equals, "%(base_dir)s/bin")
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.Equals, "%(base_dir)s/bin")
 }
 
 // Get(section, option) should lookup the option in the DEFAULT section if requested
-func (s *ConfigParserSuite) TestGetDefaultSectionLowercase(c *C) {
+func (s *ConfigParserSuite) TestGetDefaultSectionLowercase(c *gc.C) {
 	result, err := s.p.Get("default", "bin_dir")
-	c.Assert(err, IsNil)
-	c.Assert(result, Equals, "%(base_dir)s/bin")
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.Equals, "%(base_dir)s/bin")
 }
 
 // Get(section, option) should lookup the value in the default section if it doesn't exist in the section
-func (s *ConfigParserSuite) TestGetWithMissingOptionInSectionButDefaultProvided(c *C) {
+func (s *ConfigParserSuite) TestGetWithMissingOptionInSectionButDefaultProvided(c *gc.C) {
 	result, err := s.p.Get("slave", "base_dir")
-	c.Assert(err, IsNil)
-	c.Assert(result, Equals, "/srv")
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.Equals, "/srv")
 }
 
 // Get(section, option) should be case insensitive with respect to options
-func (s *ConfigParserSuite) TestGetCaseInsensitiveWithOptions(c *C) {
+func (s *ConfigParserSuite) TestGetCaseInsensitiveWithOptions(c *gc.C) {
 	result, err := s.p.Get("slave", "MAX_BUILD_TIME")
-	c.Assert(err, IsNil)
-	c.Assert(result, Equals, "200")
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.Equals, "200")
 }
 
 // Set(section, option, value) should return an error if the section doesn't exist
-func (s *ConfigParserSuite) TestSetWithNoSection(c *C) {
+func (s *ConfigParserSuite) TestSetWithNoSection(c *gc.C) {
 	err := s.p.Set("unknown", "my_value", "testing")
-	c.Assert(err, ErrorMatches, "No section: 'unknown'")
+	c.Assert(err, gc.ErrorMatches, "No section: 'unknown'")
 }
 
 // Set(section, option, value) should set a default value if the section is the DEFAULT section
-func (s *ConfigParserSuite) TestSetDefaultSection(c *C) {
+func (s *ConfigParserSuite) TestSetDefaultSection(c *gc.C) {
 	s.p.Set("DEFAULT", "my_value", "testing")
 	defaults := s.p.Defaults()
-	c.Assert(defaults["my_value"], Equals, "testing")
+	c.Assert(defaults["my_value"], gc.Equals, "testing")
 }
 
 // Set(section, option, value) should record the specified value in the correct section
-func (s *ConfigParserSuite) TestSet(c *C) {
+func (s *ConfigParserSuite) TestSet(c *gc.C) {
 	s.p.Set("slave", "my_value", "newvalue")
 	result, err := s.p.Get("slave", "my_value")
-	c.Assert(err, IsNil)
-	c.Assert(result, Equals, "newvalue")
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.Equals, "newvalue")
 }
 
 // HasSection(section) should return false if the section does not exist in the configuration
-func (s *ConfigParserSuite) TestHasSectionWithoutSection(c *C) {
+func (s *ConfigParserSuite) TestHasSectionWithoutSection(c *gc.C) {
 	newParser := configparser.New()
-	c.Assert(newParser.HasSection("mysection"), Equals, false)
+	c.Assert(newParser.HasSection("mysection"), gc.Equals, false)
 }
 
 // HasSection(section) should return true if the section does exist in the configuration
-func (s *ConfigParserSuite) TestHasSectionWithSection(c *C) {
-	c.Assert(s.p.HasSection("slave"), Equals, true)
+func (s *ConfigParserSuite) TestHasSectionWithSection(c *gc.C) {
+	c.Assert(s.p.HasSection("slave"), gc.Equals, true)
 }
 
 // Items(section) should return an appropriate error if the section doesn't exist
-func (s *ConfigParserSuite) TestItemsWithNoSection(c *C) {
+func (s *ConfigParserSuite) TestItemsWithNoSection(c *gc.C) {
 	_, err := s.p.Items("unknown")
-	c.Assert(err, ErrorMatches, "No section: 'unknown'")
+	c.Assert(err, gc.ErrorMatches, "No section: 'unknown'")
 }
 
 // Items(section) should return a copy of the dict for the section
-func (s *ConfigParserSuite) TestItemsWithSection(c *C) {
+func (s *ConfigParserSuite) TestItemsWithSection(c *gc.C) {
 	result, err := s.p.Items("slave")
-	c.Assert(err, IsNil)
-	c.Assert(result, DeepEquals, configparser.Dict{
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.DeepEquals, configparser.Dict{
 		"FrobTimeout":     "5",
 		"max_build_time":  "200",
 		"builder_command": "%(bin_dir)s/build",
@@ -185,10 +185,10 @@ func (s *ConfigParserSuite) TestItemsWithSection(c *C) {
 }
 
 // Items(section) should return a copy of the dict for the section
-func (s *ConfigParserSuite) TestItemsWithDefaults(c *C) {
+func (s *ConfigParserSuite) TestItemsWithDefaults(c *gc.C) {
 	result, err := s.p.ItemsWithDefaults("slave")
-	c.Assert(err, IsNil)
-	c.Assert(result, DeepEquals, configparser.Dict{
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.DeepEquals, configparser.Dict{
 		"FrobTimeout":     "5",
 		"max_build_time":  "200",
 		"base_dir":        "/srv",
@@ -198,134 +198,151 @@ func (s *ConfigParserSuite) TestItemsWithDefaults(c *C) {
 }
 
 // GetInt64(section, option) should return the option value for the named section as an Int64 value
-func (s *ConfigParserSuite) TestGetInt64(c *C) {
+func (s *ConfigParserSuite) TestGetInt64(c *gc.C) {
 	newParser := configparser.New()
 	newParser.AddSection("testing")
 	newParser.Set("testing", "value", "200")
 
 	result, err := newParser.GetInt64("testing", "value")
-	c.Assert(err, IsNil)
-	c.Assert(result, Equals, int64(200))
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.Equals, int64(200))
 }
 
 // GetInt64(section, option) should return an appropriate error if the option does not exist
-func (s *ConfigParserSuite) TestGetInt64MissingOption(c *C) {
+func (s *ConfigParserSuite) TestGetInt64MissingOption(c *gc.C) {
 	newParser := configparser.New()
 	newParser.AddSection("testing")
 
 	_, err := newParser.GetInt64("testing", "value")
-	c.Assert(err, ErrorMatches, "No option 'value' in section: 'testing'")
+	c.Assert(err, gc.ErrorMatches, "No option 'value' in section: 'testing'")
 }
 
 // GetInt64(section, option) should return an appropriate error if the value can't be converted
-func (s *ConfigParserSuite) TestGetInt64InvalidOption(c *C) {
+func (s *ConfigParserSuite) TestGetInt64InvalidOption(c *gc.C) {
 	newParser := configparser.New()
 	newParser.AddSection("testing")
 	newParser.Set("testing", "value", "invalid")
 
 	_, err := newParser.GetInt64("testing", "value")
-	c.Assert(err, ErrorMatches, ".*invalid syntax.*")
+	c.Assert(err, gc.ErrorMatches, ".*invalid syntax.*")
 }
 
 // GetFloat64(section, option) should return the option value for the named section as a Float64 value
-func (s *ConfigParserSuite) TestGetFloat64(c *C) {
+func (s *ConfigParserSuite) TestGetFloat64(c *gc.C) {
 	newParser := configparser.New()
 	newParser.AddSection("testing")
 	newParser.Set("testing", "value", "3.14159265")
 
 	result, err := newParser.GetFloat64("testing", "value")
-	c.Assert(err, IsNil)
-	c.Assert(result, Equals, float64(3.14159265))
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.Equals, float64(3.14159265))
 }
 
 // GetFloat64(section, option) should return an appropriate error if the option does not exist
-func (s *ConfigParserSuite) TestGetFloat64MissingOption(c *C) {
+func (s *ConfigParserSuite) TestGetFloat64MissingOption(c *gc.C) {
 	newParser := configparser.New()
 	newParser.AddSection("testing")
 
 	_, err := newParser.GetFloat64("testing", "value")
-	c.Assert(err, ErrorMatches, "No option 'value' in section: 'testing'")
+	c.Assert(err, gc.ErrorMatches, "No option 'value' in section: 'testing'")
 }
 
 // GetFloat64(section, option) should return an appropriate error if the value can't be converted
-func (s *ConfigParserSuite) TestGetFloat64InvalidOption(c *C) {
+func (s *ConfigParserSuite) TestGetFloat64InvalidOption(c *gc.C) {
 	newParser := configparser.New()
 	newParser.AddSection("testing")
 	newParser.Set("testing", "value", "invalid")
 
 	_, err := newParser.GetFloat64("testing", "value")
-	c.Assert(err, ErrorMatches, ".*invalid syntax.*")
+	c.Assert(err, gc.ErrorMatches, ".*invalid syntax.*")
 }
 
 // GetBool(section, option) should return the option value for the named section as a Bool
-func (s *ConfigParserSuite) TestGetBool(c *C) {
+func (s *ConfigParserSuite) TestGetBool(c *gc.C) {
 	newParser := configparser.New()
 	newParser.AddSection("testing")
 
 	for _, value := range []string{"1", "yes", "true", "on"} {
 		newParser.Set("testing", "value", value)
 		result, err := newParser.GetBool("testing", "value")
-		c.Assert(err, IsNil)
-		c.Assert(result, Equals, true)
+		c.Assert(err, gc.IsNil)
+		c.Assert(result, gc.Equals, true)
 	}
 
 	for _, value := range []string{"0", "no", "false", "off"} {
 		newParser.Set("testing", "value", value)
 		result, err := newParser.GetBool("testing", "value")
-		c.Assert(err, IsNil)
-		c.Assert(result, Equals, false)
+		c.Assert(err, gc.IsNil)
+		c.Assert(result, gc.Equals, false)
 	}
 }
 
 // GetBool(section, option) should return an appropriate error if the value can't be converted
-func (s *ConfigParserSuite) TestGetBoolInvalidValue(c *C) {
+func (s *ConfigParserSuite) TestGetBoolInvalidValue(c *gc.C) {
 	newParser := configparser.New()
 	newParser.AddSection("testing")
 	newParser.Set("testing", "value", "testing")
 
 	_, err := newParser.GetBool("testing", "value")
-	c.Assert(err, ErrorMatches, "Not a boolean: 'testing'")
+	c.Assert(err, gc.ErrorMatches, "Not a boolean: 'testing'")
 }
 
 // RemoveSection(section) should return an appropriate error if the section doesn't exist
-func (s *ConfigParserSuite) TestRemoveSectionMissingSection(c *C) {
+func (s *ConfigParserSuite) TestRemoveSectionMissingSection(c *gc.C) {
 	err := s.p.RemoveSection("unknown")
-	c.Assert(err, ErrorMatches, "No section: 'unknown'")
+	c.Assert(err, gc.ErrorMatches, "No section: 'unknown'")
 }
 
 // RemoveSection(section) should return an appropriate error if the section doesn't exist
-func (s *ConfigParserSuite) TestRemoveSection(c *C) {
+func (s *ConfigParserSuite) TestRemoveSection(c *gc.C) {
 	newParser := configparser.New()
 	newParser.AddSection("testing1")
 	newParser.AddSection("testing2")
 	err := newParser.RemoveSection("testing1")
 
-	c.Assert(err, IsNil)
+	c.Assert(err, gc.IsNil)
 	result := newParser.Sections()
-	c.Assert(result, DeepEquals, []string{"testing2"})
+	c.Assert(result, gc.DeepEquals, []string{"testing2"})
 }
 
-// // RemoveOption(section, option) should return an appropriate error if the section doesn't exist
-// func (s *ConfigParserSuite) TestRemoveOptionMissingSection(c *C) {
-// 	err := s.p.RemoveOption("unknown", "web")
-// 	c.Assert(err, ErrorMatches, "No section: 'unknown'")
-// }
+// RemoveOption(section, option) should return an appropriate error if the section doesn't exist
+func (s *ConfigParserSuite) TestRemoveOptionMissingSection(c *gc.C) {
+	err := s.p.RemoveOption("unknown", "web")
+	c.Assert(err, gc.ErrorMatches, "No section: 'unknown'")
+}
 
-// // RemoveOption(section, option) should return an appropriate error if the option doesn't exist
-// func (s *ConfigParserSuite) TestRemoveOptionMissingOption(c *C) {
-//  err := s.p.RemoveOption("web", "unknown")
-//  c.Assert(err, ErrorMatches, "No option 'unknown' in section: 'web'")
-// }
+// RemoveOption(section, option) should return an appropriate error if the option doesn't exist
+func (s *ConfigParserSuite) TestRemoveOptionMissingOption(c *gc.C) {
+	err := s.p.RemoveOption("slave", "unknown")
+	c.Assert(err, gc.ErrorMatches, "No option 'unknown' in section: 'slave'")
+}
+
+// RemoveOption(section, option) should remove an option from the specified
+// section.
+func (s *ConfigParserSuite) TestRemoveOption(c *gc.C) {
+	err := s.p.RemoveOption("slave", "max_build_time")
+	c.Assert(err, gc.IsNil)
+	hasOption, err := s.p.HasOption("slave", "max_build_time")
+	c.Assert(err, gc.IsNil)
+	c.Assert(hasOption, gc.Equals, false)
+}
+
+// RemoveOption(section, option) does not remove options when the option doesn't
+// match the specified option exactly.
+func (s *ConfigParserSuite) TestRemoveOptionMatchesPrecisely(c *gc.C) {
+	err := s.p.RemoveOption("slave", "max_build_TIME")
+	c.Assert(err, gc.ErrorMatches, "No option 'max_build_TIME' in section: 'slave'")
+}
 
 // HasOption(section, option) should return true if section is default and the option is a default
-func (s *ConfigParserSuite) TestHasOptionFromDefaults(c *C) {
+func (s *ConfigParserSuite) TestHasOptionFromDefaults(c *gc.C) {
 	result, err := s.p.HasOption("DEFAULT", "base_dir")
-	c.Assert(err, IsNil)
-	c.Assert(result, Equals, true)
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.Equals, true)
 }
 
 // HasOption(section, option) should return an appropriate error if the section does not exist
-func (s *ConfigParserSuite) TestHasOptionMissingSection(c *C) {
+func (s *ConfigParserSuite) TestHasOptionMissingSection(c *gc.C) {
 	_, err := s.p.HasOption("unknown", "missing")
-	c.Assert(err, ErrorMatches, "No section: 'unknown'")
+	c.Assert(err, gc.ErrorMatches, "No section: 'unknown'")
 }

--- a/section.go
+++ b/section.go
@@ -44,6 +44,19 @@ func (s *Section) safeKey(in string) string {
 	return strings.ToLower(strings.TrimSpace(in))
 }
 
+func (s *Section) Remove(key string) error {
+	_, present := s.options[key]
+	if !present {
+		return getNoOptionError(s.Name, key)
+	}
+
+	// delete doesn't return anything, but this does require
+	// that the passed key to be removed matches the options key.
+	delete(s.lookup, s.safeKey(key))
+	delete(s.options, key)
+	return nil
+}
+
 func newSection(name string) *Section {
 	return &Section{
 		Name:    name,


### PR DESCRIPTION
Implement RemoveOption from section, only remove exact matches.

Change import references to use new gocheck location, and don't import to
package namespace.

Add MIT LICENSE file.