### PR TITLE
Don't lowercase values

### DIFF
--- a/example.cfg
+++ b/example.cfg
@@ -13,3 +13,4 @@ FrobTimeout: 5
 max_build_time: 200
 builder_command: %(bin_dir)s/build
 log_dir: %(base_dir)s/logs
+TableName: MyCaseSensitiveTableName

--- a/interpolation_test.go
+++ b/interpolation_test.go
@@ -42,6 +42,7 @@ func (s *ConfigParserSuite) TestItemsWithDefaultsInterpolated(c *C) {
 		"builder_command": "/srv/bin/build",
 		"bin_dir":         "/srv/bin",
 		"FrobTimeout":     "5",
+		"TableName":       "MyCaseSensitiveTableName",
 		"max_build_time":  "200",
 		"log_dir":         "/srv/logs",
 		"base_dir":        "/srv"})

--- a/methods_test.go
+++ b/methods_test.go
@@ -68,7 +68,7 @@ func (s *ConfigParserSuite) TestOptionsWithNoSection(c *gc.C) {
 func (s *ConfigParserSuite) TestOptionsWithSection(c *gc.C) {
 	result, err := s.p.Options("slave")
 	c.Assert(err, gc.IsNil)
-	c.Assert(result, gc.DeepEquals, []string{"FrobTimeout", "base_dir", "bin_dir", "builder_command", "log_dir", "max_build_time"})
+	c.Assert(result, gc.DeepEquals, []string{"FrobTimeout", "TableName", "base_dir", "bin_dir", "builder_command", "log_dir", "max_build_time"})
 }
 
 // Options(section) should return an empty slice if there are no options in a section
@@ -105,6 +105,14 @@ func (s *ConfigParserSuite) TestGetCamelCase(c *gc.C) {
 	result, err := s.p.Get("slave", "FrobTimeout")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.Equals, "5")
+}
+
+// Get(section, option) should return the option value for the named section
+// without mangling the value's case
+func (s *ConfigParserSuite) TestValueCasePreservation(c *gc.C) {
+	result, err := s.p.Get("slave", "TableName")
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.Equals, "MyCaseSensitiveTableName")
 }
 
 // Get(section, option) should lookup the option in the DEFAULT section if requested
@@ -179,6 +187,7 @@ func (s *ConfigParserSuite) TestItemsWithSection(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, configparser.Dict{
 		"FrobTimeout":     "5",
+		"TableName":       "MyCaseSensitiveTableName",
 		"max_build_time":  "200",
 		"builder_command": "%(bin_dir)s/build",
 		"log_dir":         "%(base_dir)s/logs"})
@@ -190,6 +199,7 @@ func (s *ConfigParserSuite) TestItemsWithDefaults(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, configparser.Dict{
 		"FrobTimeout":     "5",
+		"TableName":       "MyCaseSensitiveTableName",
 		"max_build_time":  "200",
 		"base_dir":        "/srv",
 		"builder_command": "%(bin_dir)s/build",

--- a/section.go
+++ b/section.go
@@ -36,8 +36,7 @@ func (s *Section) Items() Dict {
 }
 
 func (s *Section) safeValue(in string) string {
-	// Same as safeKey for now.
-	return s.safeKey(in)
+	return strings.TrimSpace(in)
 }
 
 func (s *Section) safeKey(in string) string {


### PR DESCRIPTION
Trim spaces from around the value, but don't run it through
strings.ToLower() too.