### PR TITLE
Strip spaces in keys

### DIFF
--- a/configparser.go
+++ b/configparser.go
@@ -125,7 +125,7 @@ func parseFile(file *os.File) (*ConfigParser, error) {
 			if curSect == nil {
 				return nil, fmt.Errorf("Missing Section Header: %d %s", lineNo, line)
 			} else {
-				curSect.Add(match[1], match[3])
+				curSect.Add(strings.TrimSpace(match[1]), match[3])
 			}
 		}
 	}


### PR DESCRIPTION
In the moment, this line: "foo = bar" will be parsed to these groups: "foo = bar", "foo ", "=", "bar" (see the trailing space in "foo ".

The regex is not the problem, it's the same as in the python ConfigParser. But in python, the key is stripped:

```
if mo:
    optname, vi, optval = mo.group('option', 'vi', 'value')
    optname = self.optionxform(optname.rstrip())
```
(see e.g. `/usr/lib/python2.7/ConfigParser.py` on a linux installation, line 516 to 518)
I don't know what's the reason for not handle this in the regex, but i'd rather not touch the pattern without knowing the reason...
The easiest fix for that is to add a TrimSpace as well