### PR TITLE
Strip spaces in keys

### DIFF
--- a/configparser.go
+++ b/configparser.go
@@ -125,7 +125,7 @@ func parseFile(file *os.File) (*ConfigParser, error) {
 			if curSect == nil {
 				return nil, fmt.Errorf("Missing Section Header: %d %s", lineNo, line)
 			} else {
-				curSect.Add(match[1], match[3])
+				curSect.Add(strings.TrimSpace(match[1]), match[3])
 			}
 		}
 	}

--- a/configparser.go
+++ b/configparser.go
@@ -33,9 +33,14 @@ var boolMapping = map[string]bool{
 	"no":    false,
 }
 
+// Dict is a simple string->string map.
 type Dict map[string]string
+
+// Config represents a Python style configuration file.
 type Config map[string]*Section
 
+// ConfigParser ties together a Config and default values for use in
+// interpolated configuration values.
 type ConfigParser struct {
 	config   Config
 	defaults *Section
@@ -61,6 +66,7 @@ func getNoOptionError(section, option string) error {
 	return fmt.Errorf("No option '%s' in section: '%s'", option, section)
 }
 
+// New creates a new ConfigParser.
 func New() *ConfigParser {
 	return &ConfigParser{
 		config:   make(Config),
@@ -68,6 +74,8 @@ func New() *ConfigParser {
 	}
 }
 
+// NewWithDefaults allows creation of a new ConfigParser with a pre-existing
+// Dict.
 func NewWithDefaults(defaults Dict) *ConfigParser {
 	p := ConfigParser{
 		config:   make(Config),
@@ -79,7 +87,8 @@ func NewWithDefaults(defaults Dict) *ConfigParser {
 	return &p
 }
 
-// Create a new ConfigParser struct populated from the supplied filename
+// NewConfigParserFromFile creates a new ConfigParser struct populated from the
+// supplied filename.
 func NewConfigParserFromFile(filename string) (*ConfigParser, error) {
 	p, err := Parse(filename)
 	if err != nil {
@@ -124,14 +133,14 @@ func parseFile(file *os.File) (*ConfigParser, error) {
 		} else if match = keyValue.FindStringSubmatch(line); len(match) > 0 {
 			if curSect == nil {
 				return nil, fmt.Errorf("Missing Section Header: %d %s", lineNo, line)
-			} else {
-				curSect.Add(strings.TrimSpace(match[1]), match[3])
 			}
+			curSect.Add(strings.TrimSpace(match[1]), match[3])
 		}
 	}
 	return p, nil
 }
 
+// Parse takes a filename and parses it into a ConfigParser value.
 func Parse(filename string) (*ConfigParser, error) {
 	file, err := os.Open(filename)
 	if err != nil {
@@ -160,7 +169,8 @@ func writeSection(file *os.File, delimiter string, section *Section) error {
 	return err
 }
 
-// Save the current state of the ConfigParser to the named file with the specified delimiter
+// SaveWithDelimiter writes the current state of the ConfigParser to the named
+// file with the specified delimiter.
 func (p *ConfigParser) SaveWithDelimiter(filename, delimiter string) error {
 	f, err := os.Create(filename)
 	defer f.Close()

--- a/example.cfg
+++ b/example.cfg
@@ -8,7 +8,7 @@
 base_dir: /srv
 bin_dir: %(base_dir)s/bin
 
-[slave]
+[follower]
 FrobTimeout: 5
 max_build_time: 200
 builder_command: %(bin_dir)s/build

--- a/example.cfg
+++ b/example.cfg
@@ -14,3 +14,6 @@ max_build_time: 200
 builder_command: %(bin_dir)s/build
 log_dir: %(base_dir)s/logs
 TableName: MyCaseSensitiveTableName
+
+[whitespace]
+foo = bar

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/bigkevmcd/go-configparser
+
+go 1.12
+
+require (
+	github.com/kr/pretty v0.1.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/interpolation.go
+++ b/interpolation.go
@@ -14,9 +14,10 @@ func (p *ConfigParser) getInterpolated(section, option string, c *chainmap.Chain
 	return p.interpolate(val, c), nil
 }
 
-// return a string value for the named option.  All % interpolations are
-// expanded in the return values, based on the defaults passed into the
-// constructor and the DEFAULT section.
+// GetInterpolated returns a string value for the named option.
+//
+// All % interpolations are expanded in the return values, based on
+// the defaults passed into the constructor and the DEFAULT section.
 func (p *ConfigParser) GetInterpolated(section, option string) (string, error) {
 	o, err := p.Items(section)
 	if err != nil {
@@ -26,9 +27,10 @@ func (p *ConfigParser) GetInterpolated(section, option string) (string, error) {
 	return p.getInterpolated(section, option, c)
 }
 
-// return a string value for the named option.  All % interpolations are
-// expanded in the return values, based on the defaults passed into the
-// constructor and the DEFAULT section.  Additional substitutions may be
+// GetInterpolatedWithVars returns a string value for the named option.
+//
+// All % interpolations are expanded in the return values, based on the defaults passed
+// into the constructor and the DEFAULT section.  Additional substitutions may be
 // provided using the 'v' argument, which must be a Dict whose contents contents
 // override any pre-existing defaults.
 func (p *ConfigParser) GetInterpolatedWithVars(section, option string, v Dict) (string, error) {
@@ -43,7 +45,7 @@ func (p *ConfigParser) GetInterpolatedWithVars(section, option string, v Dict) (
 
 // Private method which does the work of interpolating a value
 // interpolates the value using the values in the ChainMap
-// returns the interpolated string
+// returns the interpolated string.
 func (p *ConfigParser) interpolate(value string, options *chainmap.ChainMap) string {
 
 	for i := 0; i < maxInterpolationDepth; i++ {
@@ -59,7 +61,7 @@ func (p *ConfigParser) interpolate(value string, options *chainmap.ChainMap) str
 	return value
 }
 
-// return a copy of the dict for the section
+// ItemsWithDefaultsInterpolated returns a copy of the dict for the section.
 func (p *ConfigParser) ItemsWithDefaultsInterpolated(section string) (Dict, error) {
 	s, err := p.ItemsWithDefaults(section)
 	if err != nil {

--- a/interpolation_test.go
+++ b/interpolation_test.go
@@ -14,7 +14,7 @@ func (s *ConfigParserSuite) TestGetInterpolatedWithMissingSection(c *C) {
 
 // GetInterpolated(section, option) should interpolate the result
 func (s *ConfigParserSuite) TestGetInterpolated(c *C) {
-	result, err := s.p.GetInterpolated("slave", "builder_command")
+	result, err := s.p.GetInterpolated("follower", "builder_command")
 
 	c.Assert(err, IsNil)
 	c.Assert(result, Equals, "/srv/bin/build")
@@ -26,7 +26,7 @@ func (s *ConfigParserSuite) TestGetInterpolatedWithVars(c *C) {
 	d := make(configparser.Dict)
 	d["bin_dir"] = "/a/non/existent/path"
 
-	result, err := s.p.GetInterpolatedWithVars("slave", "builder_command", d)
+	result, err := s.p.GetInterpolatedWithVars("follower", "builder_command", d)
 
 	c.Assert(err, IsNil)
 	c.Assert(result, Equals, "/a/non/existent/path/build")
@@ -35,7 +35,7 @@ func (s *ConfigParserSuite) TestGetInterpolatedWithVars(c *C) {
 // ItemsInterpolated(section) should return a copy of the section Dict
 // but with the values interpolated
 func (s *ConfigParserSuite) TestItemsWithDefaultsInterpolated(c *C) {
-	result, err := s.p.ItemsWithDefaultsInterpolated("slave")
+	result, err := s.p.ItemsWithDefaultsInterpolated("follower")
 
 	c.Assert(err, IsNil)
 	c.Assert(result, DeepEquals, configparser.Dict{

--- a/methods.go
+++ b/methods.go
@@ -11,24 +11,26 @@ func (p *ConfigParser) isDefaultSection(section string) bool {
 	return strings.ToLower(section) == strings.ToLower(defaultSectionName)
 }
 
+// Defaults returns the items in the map used for default values.
 func (p *ConfigParser) Defaults() Dict {
 	return p.defaults.Items()
 }
 
-// Return a list of section names, excluding [DEFAULT].
+// Sections returns a list of section names, excluding [DEFAULT].
 func (p *ConfigParser) Sections() []string {
 	sections := make([]string, 0)
-	for section, _ := range p.config {
+	for section := range p.config {
 		sections = append(sections, section)
 	}
 	sort.Strings(sections)
 	return sections
 }
 
-// Create a new section in the configuration.
+// AddSection creates a new section in the configuration.
+//
 // Returns an error if a section by the specified name
 // already exists.
-// Returns an error if the specified nanme DEFAULT or any of it's
+// Returns an error if the specified name DEFAULT or any of its
 // case-insensitive variants.
 // Returns nil if no error and the section is created
 func (p *ConfigParser) AddSection(section string) error {
@@ -41,14 +43,17 @@ func (p *ConfigParser) AddSection(section string) error {
 	return nil
 }
 
-// Indicate whether the named section is present in the configuration.
+// HasSection returns true if the named section is present in the
+// configuration.
+//
 // The DEFAULT section is not acknowledged.
 func (p *ConfigParser) HasSection(section string) bool {
 	_, present := p.config[section]
 	return present
 }
 
-// Return a list of option names for the given section name.
+// Options returns a list of option mames for the given section name.
+//
 // Returns an error if the section does not exist.
 func (p *ConfigParser) Options(section string) ([]string, error) {
 	if !p.HasSection(section) {
@@ -62,14 +67,15 @@ func (p *ConfigParser) Options(section string) ([]string, error) {
 		seenOptions[option] = true
 	}
 	options := make([]string, 0)
-	for option, _ := range seenOptions {
+	for option := range seenOptions {
 		options = append(options, option)
 	}
 	sort.Strings(options)
 	return options, nil
 }
 
-// return a string value for the named option.
+// Get returns string value for the named option.
+//
 // Returns an error if a section does not exist
 // Returns an error if the option does not exist either in the section or in
 // the defaults
@@ -91,7 +97,9 @@ func (p *ConfigParser) Get(section, option string) (string, error) {
 	return "", getNoOptionError(section, option)
 }
 
-// return a copy of the section Dict including any values from the Defaults
+// ItemsWithDefaults returns a copy of the named section Dict including
+// any values from the Defaults.
+//
 // NOTE: This is different from the Python version which returns a list of
 // tuples
 func (p *ConfigParser) ItemsWithDefaults(section string) (Dict, error) {
@@ -109,7 +117,8 @@ func (p *ConfigParser) ItemsWithDefaults(section string) (Dict, error) {
 	return s, nil
 }
 
-// return a copy of the section Dict not including the Defaults
+// Items returns a copy of the section Dict not including the Defaults.
+//
 // NOTE: This is different from the Python version which returns a list of
 // tuples
 func (p *ConfigParser) Items(section string) (Dict, error) {
@@ -119,8 +128,9 @@ func (p *ConfigParser) Items(section string) (Dict, error) {
 	return p.config[section].Items(), nil
 }
 
-// set the given option
-// returns an error if the section does not exist
+// Set puts the given option into the named section.
+//
+// Returns an error if the section does not exist.
 func (p *ConfigParser) Set(section, option, value string) error {
 	var setSection *Section
 

--- a/methods_test.go
+++ b/methods_test.go
@@ -22,7 +22,7 @@ func (s *ConfigParserSuite) TestDefaultsWithNoDefaults(c *gc.C) {
 // Sections() should return a list of section names excluding [DEFAULT]
 func (s *ConfigParserSuite) TestSections(c *gc.C) {
 	result := s.p.Sections()
-	c.Assert(result, gc.DeepEquals, []string{"follower"})
+	c.Assert(result, gc.DeepEquals, []string{"follower", "whitespace"})
 }
 
 // AddSection(section) should create a new section in the configuration
@@ -355,4 +355,11 @@ func (s *ConfigParserSuite) TestHasOptionFromDefaults(c *gc.C) {
 func (s *ConfigParserSuite) TestHasOptionMissingSection(c *gc.C) {
 	_, err := s.p.HasOption("unknown", "missing")
 	c.Assert(err, gc.ErrorMatches, "No section: 'unknown'")
+}
+
+// Options(section) should strip whitespace from the keys when parsing sections.
+func (s *ConfigParserSuite) TestOptionsWithSectionStripsWhitespaceFromKeys(c *gc.C) {
+	result, err := s.p.Options("whitespace")
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.DeepEquals, []string{"base_dir", "bin_dir", "foo"})
 }

--- a/methods_test.go
+++ b/methods_test.go
@@ -22,7 +22,7 @@ func (s *ConfigParserSuite) TestDefaultsWithNoDefaults(c *gc.C) {
 // Sections() should return a list of section names excluding [DEFAULT]
 func (s *ConfigParserSuite) TestSections(c *gc.C) {
 	result := s.p.Sections()
-	c.Assert(result, gc.DeepEquals, []string{"slave"})
+	c.Assert(result, gc.DeepEquals, []string{"follower"})
 }
 
 // AddSection(section) should create a new section in the configuration
@@ -37,9 +37,9 @@ func (s *ConfigParserSuite) TestAddSection(c *gc.C) {
 
 // AddSection(section) should return an appropriate error if the section already exists
 func (s *ConfigParserSuite) TestAddSectionDuplicate(c *gc.C) {
-	err := s.p.AddSection("slave")
+	err := s.p.AddSection("follower")
 
-	c.Assert(err, gc.ErrorMatches, "Section 'slave' already exists")
+	c.Assert(err, gc.ErrorMatches, "Section 'follower' already exists")
 }
 
 // AddSection(section) should return an appropriate error if we attempt to add a default section
@@ -66,7 +66,7 @@ func (s *ConfigParserSuite) TestOptionsWithNoSection(c *gc.C) {
 
 // Options(section) should return a list of option names for a given section mixed in with the defaults
 func (s *ConfigParserSuite) TestOptionsWithSection(c *gc.C) {
-	result, err := s.p.Options("slave")
+	result, err := s.p.Options("follower")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, []string{"FrobTimeout", "TableName", "base_dir", "bin_dir", "builder_command", "log_dir", "max_build_time"})
 }
@@ -88,13 +88,13 @@ func (s *ConfigParserSuite) TestGetWithMissingSection(c *gc.C) {
 
 // Get(section, option) should return an appropriate error if the option does not exist within the section
 func (s *ConfigParserSuite) TestGetWithMissingOptionInSection(c *gc.C) {
-	_, err := s.p.Get("slave", "missing")
-	c.Assert(err, gc.ErrorMatches, "No option 'missing' in section: 'slave'")
+	_, err := s.p.Get("follower", "missing")
+	c.Assert(err, gc.ErrorMatches, "No option 'missing' in section: 'follower'")
 }
 
 // Get(section, option) should return the option value for the named section
 func (s *ConfigParserSuite) TestGet(c *gc.C) {
-	result, err := s.p.Get("slave", "max_build_time")
+	result, err := s.p.Get("follower", "max_build_time")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.Equals, "200")
 }
@@ -102,7 +102,7 @@ func (s *ConfigParserSuite) TestGet(c *gc.C) {
 // Get(section, option) should return the option value for the named section
 // regardless of case
 func (s *ConfigParserSuite) TestGetCamelCase(c *gc.C) {
-	result, err := s.p.Get("slave", "FrobTimeout")
+	result, err := s.p.Get("follower", "FrobTimeout")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.Equals, "5")
 }
@@ -110,7 +110,7 @@ func (s *ConfigParserSuite) TestGetCamelCase(c *gc.C) {
 // Get(section, option) should return the option value for the named section
 // without mangling the value's case
 func (s *ConfigParserSuite) TestValueCasePreservation(c *gc.C) {
-	result, err := s.p.Get("slave", "TableName")
+	result, err := s.p.Get("follower", "TableName")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.Equals, "MyCaseSensitiveTableName")
 }
@@ -131,14 +131,14 @@ func (s *ConfigParserSuite) TestGetDefaultSectionLowercase(c *gc.C) {
 
 // Get(section, option) should lookup the value in the default section if it doesn't exist in the section
 func (s *ConfigParserSuite) TestGetWithMissingOptionInSectionButDefaultProvided(c *gc.C) {
-	result, err := s.p.Get("slave", "base_dir")
+	result, err := s.p.Get("follower", "base_dir")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.Equals, "/srv")
 }
 
 // Get(section, option) should be case insensitive with respect to options
 func (s *ConfigParserSuite) TestGetCaseInsensitiveWithOptions(c *gc.C) {
-	result, err := s.p.Get("slave", "MAX_BUILD_TIME")
+	result, err := s.p.Get("follower", "MAX_BUILD_TIME")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.Equals, "200")
 }
@@ -158,8 +158,8 @@ func (s *ConfigParserSuite) TestSetDefaultSection(c *gc.C) {
 
 // Set(section, option, value) should record the specified value in the correct section
 func (s *ConfigParserSuite) TestSet(c *gc.C) {
-	s.p.Set("slave", "my_value", "newvalue")
-	result, err := s.p.Get("slave", "my_value")
+	s.p.Set("follower", "my_value", "newvalue")
+	result, err := s.p.Get("follower", "my_value")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.Equals, "newvalue")
 }
@@ -172,7 +172,7 @@ func (s *ConfigParserSuite) TestHasSectionWithoutSection(c *gc.C) {
 
 // HasSection(section) should return true if the section does exist in the configuration
 func (s *ConfigParserSuite) TestHasSectionWithSection(c *gc.C) {
-	c.Assert(s.p.HasSection("slave"), gc.Equals, true)
+	c.Assert(s.p.HasSection("follower"), gc.Equals, true)
 }
 
 // Items(section) should return an appropriate error if the section doesn't exist
@@ -183,7 +183,7 @@ func (s *ConfigParserSuite) TestItemsWithNoSection(c *gc.C) {
 
 // Items(section) should return a copy of the dict for the section
 func (s *ConfigParserSuite) TestItemsWithSection(c *gc.C) {
-	result, err := s.p.Items("slave")
+	result, err := s.p.Items("follower")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, configparser.Dict{
 		"FrobTimeout":     "5",
@@ -195,7 +195,7 @@ func (s *ConfigParserSuite) TestItemsWithSection(c *gc.C) {
 
 // Items(section) should return a copy of the dict for the section
 func (s *ConfigParserSuite) TestItemsWithDefaults(c *gc.C) {
-	result, err := s.p.ItemsWithDefaults("slave")
+	result, err := s.p.ItemsWithDefaults("follower")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, configparser.Dict{
 		"FrobTimeout":     "5",
@@ -323,16 +323,16 @@ func (s *ConfigParserSuite) TestRemoveOptionMissingSection(c *gc.C) {
 
 // RemoveOption(section, option) should return an appropriate error if the option doesn't exist
 func (s *ConfigParserSuite) TestRemoveOptionMissingOption(c *gc.C) {
-	err := s.p.RemoveOption("slave", "unknown")
-	c.Assert(err, gc.ErrorMatches, "No option 'unknown' in section: 'slave'")
+	err := s.p.RemoveOption("follower", "unknown")
+	c.Assert(err, gc.ErrorMatches, "No option 'unknown' in section: 'follower'")
 }
 
 // RemoveOption(section, option) should remove an option from the specified
 // section.
 func (s *ConfigParserSuite) TestRemoveOption(c *gc.C) {
-	err := s.p.RemoveOption("slave", "max_build_time")
+	err := s.p.RemoveOption("follower", "max_build_time")
 	c.Assert(err, gc.IsNil)
-	hasOption, err := s.p.HasOption("slave", "max_build_time")
+	hasOption, err := s.p.HasOption("follower", "max_build_time")
 	c.Assert(err, gc.IsNil)
 	c.Assert(hasOption, gc.Equals, false)
 }
@@ -340,8 +340,8 @@ func (s *ConfigParserSuite) TestRemoveOption(c *gc.C) {
 // RemoveOption(section, option) does not remove options when the option doesn't
 // match the specified option exactly.
 func (s *ConfigParserSuite) TestRemoveOptionMatchesPrecisely(c *gc.C) {
-	err := s.p.RemoveOption("slave", "max_build_TIME")
-	c.Assert(err, gc.ErrorMatches, "No option 'max_build_TIME' in section: 'slave'")
+	err := s.p.RemoveOption("follower", "max_build_TIME")
+	c.Assert(err, gc.ErrorMatches, "No option 'max_build_TIME' in section: 'follower'")
 }
 
 // HasOption(section, option) should return true if section is default and the option is a default


### PR DESCRIPTION
This is basically a redo of https://github.com/bigkevmcd/go-configparser/pull/8 by @BuZZ-T
 
- Also includes a test
- Makes this into a Go module
- Tidying up gometalinter issues