### PR TITLE
Close File after Parsing

### DIFF
--- a/configparser.go
+++ b/configparser.go
@@ -143,6 +143,7 @@ func parseFile(file *os.File) (*ConfigParser, error) {
 // Parse takes a filename and parses it into a ConfigParser value.
 func Parse(filename string) (*ConfigParser, error) {
 	file, err := os.Open(filename)
+	defer file.Close()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently files are not being closed after each usage, so after a period of time, the OS throws an error for the same quoting:
```
Error occured during reading the config fileopen /etc/dozee/config/poller.cfg: too many open files
```

I have added a line to defer file close in the function `Parse` which will close the file after the Config has been Parsed.