### PR TITLE
Fix Default Section Name

### DIFF
--- a/configparser.go
+++ b/configparser.go
@@ -70,7 +70,7 @@ func getNoOptionError(section, option string) error {
 func New() *ConfigParser {
 	return &ConfigParser{
 		config:   make(Config),
-		defaults: newSection("defaults"),
+		defaults: newSection("default"),
 	}
 }
 
@@ -79,7 +79,7 @@ func New() *ConfigParser {
 func NewWithDefaults(defaults Dict) *ConfigParser {
 	p := ConfigParser{
 		config:   make(Config),
-		defaults: newSection("defaults"),
+		defaults: newSection("default"),
 	}
 	for key, value := range defaults {
 		p.defaults.Add(key, value)

--- a/configparser.go
+++ b/configparser.go
@@ -70,7 +70,7 @@ func getNoOptionError(section, option string) error {
 func New() *ConfigParser {
 	return &ConfigParser{
 		config:   make(Config),
-		defaults: newSection("default"),
+		defaults: newSection(defaultSectionName),
 	}
 }
 
@@ -79,7 +79,7 @@ func New() *ConfigParser {
 func NewWithDefaults(defaults Dict) *ConfigParser {
 	p := ConfigParser{
 		config:   make(Config),
-		defaults: newSection("default"),
+		defaults: newSection(defaultSectionName),
 	}
 	for key, value := range defaults {
 		p.defaults.Add(key, value)

--- a/configparser_test.go
+++ b/configparser_test.go
@@ -94,5 +94,5 @@ func (s *ConfigParserSuite) TestSaveWithDelimiterAndDefaults(c *C) {
 	data, err := ioutil.ReadAll(f)
 	c.Assert(err, IsNil)
 	f.Close()
-	c.Assert(fmt.Sprintf("%s", data), Equals, "[defaults]\ntesting = value\n\n[othersection]\nmyoption = myvalue\nnewoption = novalue\n\n[testing]\nmyoption = value\n\n")
+	c.Assert(fmt.Sprintf("%s", data), Equals, "[default]\ntesting = value\n\n[othersection]\nmyoption = myvalue\nnewoption = novalue\n\n[testing]\nmyoption = value\n\n")
 }

--- a/configparser_test.go
+++ b/configparser_test.go
@@ -94,5 +94,5 @@ func (s *ConfigParserSuite) TestSaveWithDelimiterAndDefaults(c *C) {
 	data, err := ioutil.ReadAll(f)
 	c.Assert(err, IsNil)
 	f.Close()
-	c.Assert(fmt.Sprintf("%s", data), Equals, "[default]\ntesting = value\n\n[othersection]\nmyoption = myvalue\nnewoption = novalue\n\n[testing]\nmyoption = value\n\n")
+	c.Assert(fmt.Sprintf("%s", data), Equals, "[DEFAULT]\ntesting = value\n\n[othersection]\nmyoption = myvalue\nnewoption = novalue\n\n[testing]\nmyoption = value\n\n")
 }

--- a/methods.go
+++ b/methods.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 )
 
 func (p *ConfigParser) isDefaultSection(section string) bool {
-	return strings.ToLower(section) == strings.ToLower(defaultSectionName)
+	return section == defaultSectionName
 }
 
 // Defaults returns the items in the map used for default values.

--- a/methods_test.go
+++ b/methods_test.go
@@ -42,12 +42,12 @@ func (s *ConfigParserSuite) TestAddSectionDuplicate(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "Section 'follower' already exists")
 }
 
-// AddSection(section) should return an appropriate error if we attempt to add a default section
+// AddSection(section) should not error if we attempt to add a default section
 func (s *ConfigParserSuite) TestAddSectionDefaultLowercase(c *gc.C) {
 	newParser := configparser.New()
 	err := newParser.AddSection("default")
 
-	c.Assert(err, gc.ErrorMatches, "Invalid section name: 'default'")
+	c.Assert(err, gc.IsNil)
 }
 
 // AddSection(section) should return an appropriate error if we attempt to add a DEFAULT section
@@ -122,11 +122,10 @@ func (s *ConfigParserSuite) TestGetDefaultSection(c *gc.C) {
 	c.Assert(result, gc.Equals, "%(base_dir)s/bin")
 }
 
-// Get(section, option) should lookup the option in the DEFAULT section if requested
+// Get(section, option) should return an error as the DEFAULT section is case-sensitive
 func (s *ConfigParserSuite) TestGetDefaultSectionLowercase(c *gc.C) {
-	result, err := s.p.Get("default", "bin_dir")
-	c.Assert(err, gc.IsNil)
-	c.Assert(result, gc.Equals, "%(base_dir)s/bin")
+	_, err := s.p.Get("default", "bin_dir")
+	c.Assert(err, gc.ErrorMatches, "No section: 'default'")
 }
 
 // Get(section, option) should lookup the value in the default section if it doesn't exist in the section


### PR DESCRIPTION
Noticed I could not create a "default" section, it would get renamed to defaults.  Not sure if this is the intent, if so, maybe it could be made configurable?

In our case, we're rendering AWS configuration files (~/.aws/{config|credentials}) where there is a "default" section.

Love this project by the way... Lets me have parity with the Python version of my project.  Thank You!