### PR TITLE
Parse brackets in option value

### DIFF
--- a/configparser.go
+++ b/configparser.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	sectionHeader = regexp.MustCompile(`^\[([^]]+)\]$`) 
+	sectionHeader = regexp.MustCompile(`^\[([^]]+)\]$`)
 	keyValue      = regexp.MustCompile(`([^:=\s][^:=]*)\s*(?P<vi>[:=])\s*(.*)$`)
 	interpolater  = regexp.MustCompile(`%\(([^)]*)\)s`)
 )

--- a/configparser.go
+++ b/configparser.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	sectionHeader = regexp.MustCompile(`\[([^]]+)\]`)
+	sectionHeader = regexp.MustCompile(`^\[([^]]+)\]$`) 
 	keyValue      = regexp.MustCompile(`([^:=\s][^:=]*)\s*(?P<vi>[:=])\s*(.*)$`)
 	interpolater  = regexp.MustCompile(`%\(([^)]*)\)s`)
 )
@@ -116,7 +116,7 @@ func ParseReader(in io.Reader) (*ConfigParser, error) {
 		if len(l) == 0 {
 			continue
 		}
-		line := strings.TrimFunc(string(l), unicode.IsSpace)
+		line := strings.TrimFunc(string(l), unicode.IsSpace) // ensures sectionHeader regex will match
 
 		// Skip comment lines and empty lines
 		if strings.HasPrefix(line, "#") || line == "" {

--- a/configparser_test.go
+++ b/configparser_test.go
@@ -114,7 +114,6 @@ func (s *ConfigParserSuite) TestSaveWithDelimiterAndDefaults(c *C) {
 
 // ParseFromReader() parses the Config data from an io.Reader.
 func (s *ConfigParserSuite) TestParseFromReader(c *gc.C) {
-
 	parsed, err := configparser.ParseReader(strings.NewReader("[DEFAULT]\ntesting = value\n\n[othersection]\nmyoption = myvalue\nnewoption = novalue\nfinal = foo[bar]\n\n[testing]\nmyoption = value\n\n"))
 	c.Assert(err, gc.IsNil)
 

--- a/configparser_test.go
+++ b/configparser_test.go
@@ -114,12 +114,16 @@ func (s *ConfigParserSuite) TestSaveWithDelimiterAndDefaults(c *C) {
 
 // ParseFromReader() parses the Config data from an io.Reader.
 func (s *ConfigParserSuite) TestParseFromReader(c *gc.C) {
-	parsed, err := configparser.ParseReader(strings.NewReader("[DEFAULT]\ntesting = value\n\n[othersection]\nmyoption = myvalue\nnewoption = novalue\n\n[testing]\nmyoption = value\n\n"))
+
+	input := "[DEFAULT]\ntesting = value\n\n[othersection]\nmyoption = myvalue\nnewoption = novalue\nfinal = foo[bar]\n\n[testing]\nmyoption = value\n\n"
+	c.Logf("set input %s\n", input)
+	parsed, err := configparser.ParseReader(strings.NewReader(input))
 	c.Assert(err, gc.IsNil)
 
 	result, err := parsed.Items("othersection")
 	c.Assert(err, gc.IsNil)
-	c.Assert(result, gc.DeepEquals, configparser.Dict{"myoption": "myvalue", "newoption": "novalue"})
+	c.Assert(result, gc.DeepEquals, configparser.Dict{"myoption": "myvalue", "newoption": "novalue", "final": "foo[bar]"})
+
 }
 
 func assertSuccessful(c *gc.C, err error) {

--- a/configparser_test.go
+++ b/configparser_test.go
@@ -115,15 +115,12 @@ func (s *ConfigParserSuite) TestSaveWithDelimiterAndDefaults(c *C) {
 // ParseFromReader() parses the Config data from an io.Reader.
 func (s *ConfigParserSuite) TestParseFromReader(c *gc.C) {
 
-	input := "[DEFAULT]\ntesting = value\n\n[othersection]\nmyoption = myvalue\nnewoption = novalue\nfinal = foo[bar]\n\n[testing]\nmyoption = value\n\n"
-	c.Logf("set input %s\n", input)
-	parsed, err := configparser.ParseReader(strings.NewReader(input))
+	parsed, err := configparser.ParseReader(strings.NewReader("[DEFAULT]\ntesting = value\n\n[othersection]\nmyoption = myvalue\nnewoption = novalue\nfinal = foo[bar]\n\n[testing]\nmyoption = value\n\n"))
 	c.Assert(err, gc.IsNil)
 
 	result, err := parsed.Items("othersection")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, configparser.Dict{"myoption": "myvalue", "newoption": "novalue", "final": "foo[bar]"})
-
 }
 
 func assertSuccessful(c *gc.C, err error) {


### PR DESCRIPTION
Thanks for this library.

My use case is config file like:
```
[foo]
a = foo
b = foo[foo] foo
```
, which breaks parsing.

My work around is to adjust the sectionHeader regex, which works because input is trimmed prior to looking for regex matches.  Unsure if there are other use cases that this would break.
