### PR TITLE
add option with no value

### DIFF
--- a/configparser.go
+++ b/configparser.go
@@ -18,9 +18,13 @@ const (
 
 var (
 	sectionHeader = regexp.MustCompile(`^\[([^]]+)\]$`)
-	keyValue      = regexp.MustCompile(`([^:=\s][^:=]*)\s*((?P<vi>[:=])\s*(.*)$)?`)
+	keyValue      = regexp.MustCompile(`([^:=\s][^:=]*)\s*(?P<vi>[:=])\s*(.*)$`)
+	keyWNoValue   = regexp.MustCompile(`([^:=\s][^:=]*)\s*((?P<vi>[:=])\s*(.*)$)?`)
 	interpolater  = regexp.MustCompile(`%\(([^)]*)\)s`)
 )
+
+// AllowNoValue allows parser to save options without values as empty strings.
+var AllowNoValue bool
 
 var boolMapping = map[string]bool{
 	"1":     true,
@@ -131,10 +135,16 @@ func ParseReader(in io.Reader) (*ConfigParser, error) {
 				curSect = newSection(section)
 				p.config[section] = curSect
 			}
-		} else if match = keyValue.FindStringSubmatch(line); len(match) > 0 && curSect != nil {
+		} else if match = keyValue.FindStringSubmatch(line); len(match) > 0 {
 			if curSect == nil {
 				return nil, fmt.Errorf("missing section header: %d %s", lineNo, line)
 			}
+			key := strings.TrimSpace(match[1])
+			value := match[3]
+			if err := curSect.Add(key, value); err != nil {
+				return nil, fmt.Errorf("failed to add %q = %q: %w", key, value, err)
+			}
+		} else if match = keyWNoValue.FindStringSubmatch(line); len(match) > 0 && AllowNoValue && curSect != nil {
 			key := strings.TrimSpace(match[1])
 			value := match[4]
 			if err := curSect.Add(key, value); err != nil {

--- a/configparser.go
+++ b/configparser.go
@@ -18,7 +18,7 @@ const (
 
 var (
 	sectionHeader = regexp.MustCompile(`^\[([^]]+)\]$`)
-	keyValue      = regexp.MustCompile(`([^:=\s][^:=]*)\s*(?P<vi>[:=])\s*(.*)$`)
+	keyValue      = regexp.MustCompile(`([^:=\s][^:=]*)\s*((?P<vi>[:=])\s*(.*)$)?`)
 	interpolater  = regexp.MustCompile(`%\(([^)]*)\)s`)
 )
 
@@ -131,12 +131,12 @@ func ParseReader(in io.Reader) (*ConfigParser, error) {
 				curSect = newSection(section)
 				p.config[section] = curSect
 			}
-		} else if match = keyValue.FindStringSubmatch(line); len(match) > 0 {
+		} else if match = keyValue.FindStringSubmatch(line); len(match) > 0 && curSect != nil {
 			if curSect == nil {
 				return nil, fmt.Errorf("missing section header: %d %s", lineNo, line)
 			}
 			key := strings.TrimSpace(match[1])
-			value := match[3]
+			value := match[4]
 			if err := curSect.Add(key, value); err != nil {
 				return nil, fmt.Errorf("failed to add %q = %q: %w", key, value, err)
 			}

--- a/configparser_test.go
+++ b/configparser_test.go
@@ -124,8 +124,9 @@ func (s *ConfigParserSuite) TestParseFromReader(c *gc.C) {
 
 // If AllowNoValue is set to true, parser should recognize options without values.
 func (s *ConfigParserSuite) TestParseReaderWithOptionsWNoValue(c *gc.C) {
-	opt := &configparser.Options{AllowNoValue: true}
-	parsed, err := configparser.ParseReaderWithOptions(strings.NewReader("[empty]\noption\n\n"), opt)
+	parsed, err := configparser.ParseReaderWithOptions(
+		strings.NewReader("[empty]\noption\n\n"), configparser.AllowNoValue,
+	)
 	c.Assert(err, gc.IsNil)
 
 	ok, err := parsed.HasOption("empty", "option")
@@ -138,8 +139,9 @@ func assertSuccessful(c *gc.C, err error) {
 }
 
 func (s *ConfigParserSuite) TestParseWithOptions(c *gc.C) {
-	opt := &configparser.Options{AllowNoValue: true}
-	parsed, err := configparser.ParseWithOptions("testdata/example.cfg", opt)
+	parsed, err := configparser.ParseWithOptions(
+		"testdata/example.cfg", configparser.AllowNoValue,
+	)
 	c.Assert(err, gc.IsNil)
 
 	ok, err := parsed.HasOption("empty", "foo")

--- a/configparser_test.go
+++ b/configparser_test.go
@@ -114,7 +114,7 @@ func (s *ConfigParserSuite) TestSaveWithDelimiterAndDefaults(c *C) {
 
 // ParseFromReader() parses the Config data from an io.Reader.
 func (s *ConfigParserSuite) TestParseFromReader(c *gc.C) {
-	parsed, err := configparser.ParseReader(strings.NewReader("[DEFAULT]\ntesting = value\n\n[othersection]\nmyoption = myvalue\nnewoption = novalue\nfinal = foo[bar]\n\n[testing]\nmyoption = value\n\n"))
+	parsed, err := configparser.ParseReader(strings.NewReader("[DEFAULT]\ntesting = value\n\n[othersection]\nmyoption = myvalue\nnewoption = novalue\nfinal = foo[bar]\n\n[testing]\nmyoption = value\nemptyoption\n\n"))
 	c.Assert(err, gc.IsNil)
 
 	result, err := parsed.Items("othersection")

--- a/configparser_test.go
+++ b/configparser_test.go
@@ -122,6 +122,19 @@ func (s *ConfigParserSuite) TestParseFromReader(c *gc.C) {
 	c.Assert(result, gc.DeepEquals, configparser.Dict{"myoption": "myvalue", "newoption": "novalue", "final": "foo[bar]"})
 }
 
+// If AllowNoValue is set to true, parser should recognize options without values.
+func (s *ConfigParserSuite) TestParseFromReaderWNoValue(c *gc.C) {
+	configparser.AllowNoValue = true
+	defer func() { configparser.AllowNoValue = false }()
+
+	parsed, err := configparser.ParseReader(strings.NewReader("[empty]\noption\n\n"))
+	c.Assert(err, gc.IsNil)
+
+	ok, err := parsed.HasOption("empty", "option")
+	c.Assert(err, gc.IsNil)
+	c.Assert(ok, Equals, true)
+}
+
 func assertSuccessful(c *gc.C, err error) {
 	c.Assert(err, gc.IsNil)
 }

--- a/configparser_test.go
+++ b/configparser_test.go
@@ -123,11 +123,9 @@ func (s *ConfigParserSuite) TestParseFromReader(c *gc.C) {
 }
 
 // If AllowNoValue is set to true, parser should recognize options without values.
-func (s *ConfigParserSuite) TestParseFromReaderWNoValue(c *gc.C) {
-	configparser.AllowNoValue = true
-	defer func() { configparser.AllowNoValue = false }()
-
-	parsed, err := configparser.ParseReader(strings.NewReader("[empty]\noption\n\n"))
+func (s *ConfigParserSuite) TestParseReaderWithOptionsWNoValue(c *gc.C) {
+	opt := &configparser.Options{AllowNoValue: true}
+	parsed, err := configparser.ParseReaderWithOptions(strings.NewReader("[empty]\noption\n\n"), opt)
 	c.Assert(err, gc.IsNil)
 
 	ok, err := parsed.HasOption("empty", "option")
@@ -137,4 +135,14 @@ func (s *ConfigParserSuite) TestParseFromReaderWNoValue(c *gc.C) {
 
 func assertSuccessful(c *gc.C, err error) {
 	c.Assert(err, gc.IsNil)
+}
+
+func (s *ConfigParserSuite) TestParseWithOptions(c *gc.C) {
+	opt := &configparser.Options{AllowNoValue: true}
+	parsed, err := configparser.ParseWithOptions("testdata/example.cfg", opt)
+	c.Assert(err, gc.IsNil)
+
+	ok, err := parsed.HasOption("empty", "foo")
+	c.Assert(err, gc.IsNil)
+	c.Assert(ok, Equals, true)
 }

--- a/methods_test.go
+++ b/methods_test.go
@@ -22,7 +22,7 @@ func (s *ConfigParserSuite) TestDefaultsWithNoDefaults(c *gc.C) {
 // Sections() should return a list of section names excluding [DEFAULT]
 func (s *ConfigParserSuite) TestSections(c *gc.C) {
 	result := s.p.Sections()
-	c.Assert(result, gc.DeepEquals, []string{"follower", "whitespace"})
+	c.Assert(result, gc.DeepEquals, []string{"empty", "follower", "whitespace"})
 }
 
 // AddSection(section) should create a new section in the configuration

--- a/methods_test.go
+++ b/methods_test.go
@@ -22,7 +22,7 @@ func (s *ConfigParserSuite) TestDefaultsWithNoDefaults(c *gc.C) {
 // Sections() should return a list of section names excluding [DEFAULT]
 func (s *ConfigParserSuite) TestSections(c *gc.C) {
 	result := s.p.Sections()
-	c.Assert(result, gc.DeepEquals, []string{"empty", "follower", "whitespace"})
+	c.Assert(result, gc.DeepEquals, []string{"follower", "whitespace"})
 }
 
 // AddSection(section) should create a new section in the configuration
@@ -360,23 +360,9 @@ func (s *ConfigParserSuite) TestHasOptionMissingSection(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "no section: \"unknown\"")
 }
 
-// HasOption(section, option) should return true if option exist but has no value
-func (s *ConfigParserSuite) TestHasOptionEmptyValue(c *gc.C) {
-	hasOption, err := s.p.HasOption("empty", "foo")
-	c.Assert(err, gc.IsNil)
-	c.Assert(hasOption, gc.Equals, true)
-}
-
 // Options(section) should strip whitespace from the keys when parsing sections.
 func (s *ConfigParserSuite) TestOptionsWithSectionStripsWhitespaceFromKeys(c *gc.C) {
 	result, err := s.p.Options("whitespace")
-	c.Assert(err, gc.IsNil)
-	c.Assert(result, gc.DeepEquals, []string{"base_dir", "bin_dir", "foo"})
-}
-
-// Options(section) should read an option without a value.
-func (s *ConfigParserSuite) TestOptionsWithOptionWithoutValue(c *gc.C) {
-	result, err := s.p.Options("empty")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, []string{"base_dir", "bin_dir", "foo"})
 }

--- a/methods_test.go
+++ b/methods_test.go
@@ -22,7 +22,7 @@ func (s *ConfigParserSuite) TestDefaultsWithNoDefaults(c *gc.C) {
 // Sections() should return a list of section names excluding [DEFAULT]
 func (s *ConfigParserSuite) TestSections(c *gc.C) {
 	result := s.p.Sections()
-	c.Assert(result, gc.DeepEquals, []string{"follower", "whitespace"})
+	c.Assert(result, gc.DeepEquals, []string{"empty", "follower", "whitespace"})
 }
 
 // AddSection(section) should create a new section in the configuration
@@ -360,9 +360,23 @@ func (s *ConfigParserSuite) TestHasOptionMissingSection(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "no section: \"unknown\"")
 }
 
+// HasOption(section, option) should return true if option exist but has no value
+func (s *ConfigParserSuite) TestHasOptionEmptyValue(c *gc.C) {
+	hasOption, err := s.p.HasOption("empty", "foo")
+	c.Assert(err, gc.IsNil)
+	c.Assert(hasOption, gc.Equals, true)
+}
+
 // Options(section) should strip whitespace from the keys when parsing sections.
 func (s *ConfigParserSuite) TestOptionsWithSectionStripsWhitespaceFromKeys(c *gc.C) {
 	result, err := s.p.Options("whitespace")
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.DeepEquals, []string{"base_dir", "bin_dir", "foo"})
+}
+
+// Options(section) should read an option without a value.
+func (s *ConfigParserSuite) TestOptionsWithOptionWithoutValue(c *gc.C) {
+	result, err := s.p.Options("empty")
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.DeepEquals, []string{"base_dir", "bin_dir", "foo"})
 }

--- a/options.go
+++ b/options.go
@@ -1,0 +1,12 @@
+package configparser
+
+type options struct {
+	allowNoValue bool
+}
+
+// OptFunc modifies options.
+type OptFunc func(*options)
+
+// AllowNoValue allows option with no value to be saved
+// as empty line.
+func AllowNoValue(o *options) { o.allowNoValue = true }

--- a/testdata/example.cfg
+++ b/testdata/example.cfg
@@ -17,6 +17,3 @@ TableName: MyCaseSensitiveTableName
 
 [whitespace]
 foo = bar
-
-[empty]
-foo

--- a/testdata/example.cfg
+++ b/testdata/example.cfg
@@ -17,3 +17,6 @@ TableName: MyCaseSensitiveTableName
 
 [whitespace]
 foo = bar
+
+[empty]
+foo


### PR DESCRIPTION
Many thanks for the library!

One of my python projects was using `configparser`. When I had switched to golang I found out that it does not support bare options without values. It simply passes them, since they do not match regex.

In some config files they were used as simple flags (bool values) which triggers true with `HasOption` e.g.,
```
[OPTIONS]
rewrite
```

This MR updates regex to parse those values as empty strings, so at least they will be presented in `Dict`.

Check #17 for details