### PR TITLE
rework Get* methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ func main() {
 }
 ```
 Those functions triggered inside `ConfigParser.Get*` methods if presented and wraps the return value. 
-> NOTE: Since `ConvertFunc` returns `any`, the caller should guarantee type assertion to the requested type after custom processing!
 ```go
 type Converter map[string]ConvertFunc
 ```

--- a/methods.go
+++ b/methods.go
@@ -93,7 +93,7 @@ func (p *ConfigParser) Get(section, option string) (string, error) {
 		return "", err
 	}
 
-	return value.(string), nil
+	return assertValue[string](value)
 }
 
 func (p *ConfigParser) get(section, option string) (string, error) {
@@ -193,7 +193,7 @@ func (p *ConfigParser) GetInt64(section, option string) (int64, error) {
 		return 0, err
 	}
 
-	return value.(int64), nil
+	return assertValue[int64](value)
 }
 
 // GetFloat64 returns float64 representation of the named option.
@@ -212,7 +212,7 @@ func (p *ConfigParser) GetFloat64(section, option string) (float64, error) {
 		return 0, err
 	}
 
-	return value.(float64), nil
+	return assertValue[float64](value)
 }
 
 // GetBool returns bool representation of the named option.
@@ -231,7 +231,7 @@ func (p *ConfigParser) GetBool(section, option string) (bool, error) {
 		return false, err
 	}
 
-	return value.(bool), nil
+	return assertValue[bool](value)
 }
 
 // RemoveSection removes given section from the ConfigParser.
@@ -323,4 +323,17 @@ func defaultGetBool(value string) (any, error) {
 	}
 
 	return booleanValue, nil
+}
+
+// assertValue tries vakue assertuon to the given type, returns error if unsuccessful.
+func assertValue[T ~string | ~int64 | ~float64 | ~bool](value any) (T, error) {
+	v, ok := value.(T)
+	if ok {
+		return v, nil
+	}
+
+	// Default value of the type.
+	var d T
+
+	return d, fmt.Errorf("assertion to %T failed: incorrect value %q", d, value)
 }

--- a/options.go
+++ b/options.go
@@ -23,8 +23,6 @@ type options struct {
 }
 
 // Converter contains custom convert functions for available types.
-// The caller should guarantee type assertion to the requested type
-// after custom processing!
 type Converter map[int]ConvertFunc
 
 // Predefined types for Converter.

--- a/options.go
+++ b/options.go
@@ -143,7 +143,9 @@ func Delimiters(d string) optFunc {
 // after custom processing or the method will panic.
 func Converters(conv Converter) optFunc {
 	return func(o *options) {
-		o.converters = conv
+		for k, fn := range conv {
+			o.converters[k] = fn
+		}
 	}
 }
 


### PR DESCRIPTION
This update fixes several possible runtime panics.

1. Fix `Converters` option to replace defaults instead of replacing the whole object.
2. Add new  generic `assertValue` function, which returns an error if type assertion failed instead of panicking.