### PR TITLE
rework ParseReader

### DIFF
--- a/configparser_test.go
+++ b/configparser_test.go
@@ -150,6 +150,21 @@ broken_option = this value will miss
 	})
 }
 
+func (s *ConfigParserSuite) TestKeyValueRegexError(c *C) {
+	p := configparser.NewWithOptions(configparser.Delimiters("=-"))
+	err := p.ParseReader(strings.NewReader(""))
+	c.Assert(err, ErrorMatches, ".*error parsing regexp: invalid escape sequence.*")
+}
+
+func (s *ConfigParserSuite) TestKeyNoValueRegexError(c *C) {
+	p := configparser.NewWithOptions(
+		configparser.Delimiters("\\"),
+		configparser.AllowNoValue,
+	)
+	err := p.ParseReader(strings.NewReader(""))
+	c.Assert(err, ErrorMatches, ".*error parsing regexp: missing closing ].*")
+}
+
 func assertSuccessful(c *C, err error) {
 	c.Assert(err, IsNil)
 }

--- a/options.go
+++ b/options.go
@@ -1,6 +1,8 @@
 package configparser
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/bigkevmcd/go-configparser/chainmap"
@@ -20,6 +22,31 @@ type options struct {
 	allowNoValue          bool
 	emptyLines            bool
 	strict                bool
+}
+
+func (o *options) compileRegex() (
+	keyValue *regexp.Regexp, keyWNoValue *regexp.Regexp, err error,
+) {
+	if o.allowNoValue {
+		keyWNoValue, err = regexp.Compile(
+			fmt.Sprintf(
+				`([^%[1]s\s][^%[1]s]*)\s*((?P<vi>[%[1]s]+)\s*(.*)$)?`,
+				o.delimiters,
+			),
+		)
+		if err != nil {
+			return
+		}
+	}
+
+	keyValue, err = regexp.Compile(
+		fmt.Sprintf(
+			`([^%[1]s\s][^%[1]s]*)\s*(?P<vi>[%[1]s]+)\s*(.*)$`,
+			o.delimiters,
+		),
+	)
+
+	return
 }
 
 // Converter contains custom convert functions for available types.


### PR DESCRIPTION
This update moves regex creation for Key/Value pairs to options and replaces `Must` with error. Thus, if user passes incompatible value for **delimeters** parser will return an error instead of a panic